### PR TITLE
Release v0.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@earlysloth/pocketsurvey-ui-components",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "module": "dist/index.js",
   "repository": "https://github.com/FJOQWIERMDNKFAJ/pocketsurvey-ui-components.git",
   "author": "earlysloth <survey@earlysloth.com>",

--- a/src/Changelog.stories.mdx
+++ b/src/Changelog.stories.mdx
@@ -8,6 +8,10 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 ui 컴포넌트에 반영된 사항들입니다
 
+## 0.8.5 (2021.10.01)
+
+- 차트 레이블 길이 잡을 때 해당 차트의 svg 너비를 얻기까지 루프를 도는 로직 추가
+
 ## 0.8.4 (2021.10.01)
 
 - barVerticalSeperated 레이블 소수점 첫째자리까지

--- a/src/Chart/charts/barVerticalBase.tsx
+++ b/src/Chart/charts/barVerticalBase.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import { getPreset, BarVerticalBasePresetType } from '../util/preset';
 import { getSizeCSS, mergeOption, color } from '../util/index';
 import { scrollBar } from '../style';
+import { getLineWidth } from './barVerticalSeparated';
 
 type BarVerticalBaseOptionPropsType = {
   series: number[];
@@ -139,10 +140,8 @@ function BarVerticalBase({
   const minWidth = sizeValue * series.length + 200;
 
   const calcSVGPathLineWidth = () => {
-    const svg = targetRef.current?.querySelector(
-      'svg > g:last-child > path',
-    ) as SVGSVGElement;
-    setLineWidth(svg?.getBBox()?.width);
+    const svgLineWidth = getLineWidth(targetRef);
+    setLineWidth(svgLineWidth);
     const clientWidth = targetRef.current?.clientWidth;
     if (clientWidth) {
       setMinify(minWidth > clientWidth);

--- a/src/Chart/charts/barVerticalBase.tsx
+++ b/src/Chart/charts/barVerticalBase.tsx
@@ -7,7 +7,7 @@ import styled from 'styled-components';
 import { getPreset, BarVerticalBasePresetType } from '../util/preset';
 import { getSizeCSS, mergeOption, color } from '../util/index';
 import { scrollBar } from '../style';
-import { getLineWidth } from './barVerticalSeparated';
+import getLineWidth from '../util/getLineWidth';
 
 type BarVerticalBaseOptionPropsType = {
   series: number[];
@@ -139,8 +139,8 @@ function BarVerticalBase({
   const sizeValue = 70;
   const minWidth = sizeValue * series.length + 200;
 
-  const calcSVGPathLineWidth = () => {
-    const svgLineWidth = getLineWidth(targetRef);
+  const calcSVGPathLineWidth = async () => {
+    const svgLineWidth = await getLineWidth(targetRef);
     setLineWidth(svgLineWidth);
     const clientWidth = targetRef.current?.clientWidth;
     if (clientWidth) {

--- a/src/Chart/charts/barVerticalSeparated.tsx
+++ b/src/Chart/charts/barVerticalSeparated.tsx
@@ -15,6 +15,7 @@ import {
 import { stackedFormatter } from '../util/tooltip';
 import { scrollBar } from '../style';
 import { ellipsisPieChartData, zipChartData } from '../util/chartData';
+import getLineWidth from '../util/getLineWidth';
 
 type BarVerticalSeparatedOptionPropsType = {
   series: number[][];
@@ -75,7 +76,9 @@ const compressedSeries = (series: number[][], label: string[]) => {
   }
   // console.log("compressSeriesArr", compressSeriesArr)
 
-  const arr2D = Array(series.length + 1).fill(0).map((x) => Array(series[0].length).fill(0));
+  const arr2D = Array(series.length + 1)
+    .fill(0)
+    .map((x) => Array(series[0].length).fill(0));
   for (let i = 0; i < compressSeriesArr.length; i += 1) {
     for (let j = 0; j < compressSeriesArr[i].length; j += 1) {
       arr2D[j][i] = compressSeriesArr[i][j];
@@ -84,7 +87,12 @@ const compressedSeries = (series: number[][], label: string[]) => {
   return arr2D;
 };
 
-const getSeries = (isHundredPercent: boolean, series: number[][], label: string[], colors: string[]) => {
+const getSeries = (
+  isHundredPercent: boolean,
+  series: number[][],
+  label: string[],
+  colors: string[],
+) => {
   series = isHundredPercent ? seriesToPercentArray(series) : series;
   const seriesData: {
     data: number[];
@@ -127,7 +135,9 @@ const barVerticalSeparatedOption = ({
   const colors = getColors.barStacked(series.length);
   const percentSeries = seriesToPercentArray(series);
 
-  const rawData = series.map((_, colIndex) => series.map((row) => row[colIndex]));
+  const rawData = series.map((_, colIndex) =>
+    series.map((row) => row[colIndex]),
+  );
   const dataLength = rawData[0].length;
 
   if (dataLength > 6) {
@@ -144,25 +154,22 @@ const barVerticalSeparatedOption = ({
     colors,
   ) as EChartsOption['series'];
 
-  const toFixedSeries = series.map((series) => series.map((item) => parseFloat(item.toFixed(1))))
+  const toFixedSeries = series.map((series) =>
+    series.map((item) => parseFloat(item.toFixed(1))),
+  );
   option.tooltip = {
     trigger: 'axis',
     axisPointer: {
       type: 'shadow',
     },
-    formatter: (params: any) => stackedFormatter(
-      params,
-      toFixedSeries,
-      'vertical-separated',
-      hundredPercent?.tooltip ?? false,
-    ),
-    position(
-      pos: any,
-      params: any,
-      el: any,
-      elRect: any,
-      size: any,
-    ) {
+    formatter: (params: any) =>
+      stackedFormatter(
+        params,
+        toFixedSeries,
+        'vertical-separated',
+        hundredPercent?.tooltip ?? false,
+      ),
+    position(pos: any, params: any, el: any, elRect: any, size: any) {
       if (labelOption === 'fixed') {
         const obj: any = { top: 10 };
         obj[['left', 'right'][+(pos[0] < size.viewSize[0] / 2)]] = 30;
@@ -220,28 +227,19 @@ const EchartsWrapper = styled.div<{
 }>`
   ${scrollBar}
   ${(props) => props.minify && 'overflow-x: scroll;'}
-  ${(props) => (props.width
-    ? typeof props.width === 'number'
-      ? `width: ${props.width}px;`
-      : `width: ${props.width};`
-    : '')}
-  ${(props) => (props.height
-    ? typeof props.height === 'number'
-      ? `height: ${props.height}px;`
-      : `height: ${props.height};`
-    : '')}
+  ${(props) =>
+    props.width
+      ? typeof props.width === 'number'
+        ? `width: ${props.width}px;`
+        : `width: ${props.width};`
+      : ''}
+  ${(props) =>
+    props.height
+      ? typeof props.height === 'number'
+        ? `height: ${props.height}px;`
+        : `height: ${props.height};`
+      : ''}
 `;
-
-export const getLineWidth = (ref: React.RefObject<HTMLDivElement>) => {
-  while (true) {
-    const svg = ref.current?.querySelector(
-      'svg > g:last-child > path',
-    ) as SVGSVGElement;
-    if (svg.getBBox()) {
-      return svg.getBBox().width;
-    }
-  }
-}
 
 function BarVerticalSeparated({
   width,
@@ -260,9 +258,8 @@ function BarVerticalSeparated({
   const sizeValue = series.length * 30;
   const minWidth = sizeValue * xAxisLabel.length + 200;
 
-
-  const calcSVGPathLineWidth = () => {
-    const svgLineWidth = getLineWidth(targetRef);
+  const calcSVGPathLineWidth = async () => {
+    const svgLineWidth = await getLineWidth(targetRef);
     setLineWidth(svgLineWidth);
     const clientWidth = targetRef.current?.clientWidth;
     if (clientWidth) {
@@ -276,12 +273,13 @@ function BarVerticalSeparated({
   );
 
   const resizeObject = useResizeDetector({ targetRef });
+
   React.useEffect(() => {
     calcSVGPathLineWidth();
   }, []);
 
   React.useEffect(() => {
-    delayed()
+    delayed();
   }, [resizeObject.width]);
 
   return (

--- a/src/Chart/charts/barVerticalStacked.tsx
+++ b/src/Chart/charts/barVerticalStacked.tsx
@@ -14,6 +14,7 @@ import {
   color,
 } from '../util/index';
 import { scrollBar } from '../style';
+import { getLineWidth } from './barVerticalSeparated';
 
 type BarVerticalStackedOptionPropsType = {
   series: (number | null)[][];
@@ -264,10 +265,8 @@ function BarVerticalStacked({
 
   const minWidth = sizeValue * xAxisLabel.length + 200;
   const calcSVGPathLineWidth = () => {
-    const svg = targetRef.current?.querySelector(
-      'svg > g:last-child > path',
-    ) as SVGSVGElement;
-    setLineWidth(svg?.getBBox()?.width);
+    const svgLineWidth = getLineWidth(targetRef);
+    setLineWidth(svgLineWidth);
     const clientWidth = targetRef.current?.clientWidth;
     if (clientWidth) {
       setMinify(minWidth > clientWidth);

--- a/src/Chart/charts/barVerticalStacked.tsx
+++ b/src/Chart/charts/barVerticalStacked.tsx
@@ -14,7 +14,7 @@ import {
   color,
 } from '../util/index';
 import { scrollBar } from '../style';
-import { getLineWidth } from './barVerticalSeparated';
+import getLineWidth from '../util/getLineWidth';
 
 type BarVerticalStackedOptionPropsType = {
   series: (number | null)[][];
@@ -73,9 +73,10 @@ const barVerticalStackedOption = ({
 
   const percentSeries = seriesToPercentArray(series);
 
-  const colors = nps === true
-    ? [color.NPS.RED, color.NPS.YELLOW, color.NPS.GREEN]
-    : getColors.barStacked(series.length);
+  const colors =
+    nps === true
+      ? [color.NPS.RED, color.NPS.YELLOW, color.NPS.GREEN]
+      : getColors.barStacked(series.length);
 
   option.series = (hundredPercent?.series === true
     ? percentSeries
@@ -126,10 +127,10 @@ const barVerticalStackedOption = ({
   for (let i = option.series.length - 1; i >= 0; i -= 1) {
     (option.series[i].data as DataType).forEach((item, index) => {
       if (
-        option.series !== undefined
-        && border[index] === false
-        && item.value !== null
-        && item.value !== 0
+        option.series !== undefined &&
+        border[index] === false &&
+        item.value !== null &&
+        item.value !== 0
       ) {
         (option.series as SeriesType)[i].data[index].itemStyle = {
           ...(option.series as SeriesType)[i].data[index].itemStyle,
@@ -146,7 +147,9 @@ const barVerticalStackedOption = ({
       option.series.push({
         color: getColors.barStacked(series.length),
         //  color: getColors.pie(series.length, maxIndex),
-        data: line[i].series.map(item => item ? parseFloat(item.toFixed(1)) : null) as number[],
+        data: line[i].series.map((item) =>
+          item ? parseFloat(item.toFixed(1)) : null,
+        ) as number[],
         name: line[i].name,
         type: 'line',
         symbolSize: nps === true ? 3 : 0,
@@ -174,12 +177,13 @@ const barVerticalStackedOption = ({
     axisPointer: {
       type: 'shadow',
     },
-    formatter: (params: any) => stackedFormatter(
-      params,
-      series,
-      'vertical',
-      hundredPercent?.tooltip ?? false,
-    ),
+    formatter: (params: any) =>
+      stackedFormatter(
+        params,
+        series,
+        'vertical',
+        hundredPercent?.tooltip ?? false,
+      ),
     position(pos: any, params: any, el: any, elRect: any, size: any) {
       if (labelOption === 'fixed') {
         const obj: any = { top: 10 };
@@ -215,16 +219,18 @@ const EchartsWrapper = styled.div<{
 }>`
   ${scrollBar}
   ${(props) => props.minify && 'overflow-x: scroll;'}
-  ${(props) => (props.width
-    ? typeof props.width === 'number'
-      ? `width: ${props.width}px;`
-      : `width: ${props.width};`
-    : '')}
-  ${(props) => (props.height
-    ? typeof props.height === 'number'
-      ? `height: ${props.height}px;`
-      : `height: ${props.height};`
-    : '')}
+  ${(props) =>
+    props.width
+      ? typeof props.width === 'number'
+        ? `width: ${props.width}px;`
+        : `width: ${props.width};`
+      : ''}
+  ${(props) =>
+    props.height
+      ? typeof props.height === 'number'
+        ? `height: ${props.height}px;`
+        : `height: ${props.height};`
+      : ''}
   ${(props) => props.isOverflow && 'overflow-y: scroll;'}
 `;
 
@@ -264,8 +270,8 @@ function BarVerticalStacked({
   const sizeValue = 70;
 
   const minWidth = sizeValue * xAxisLabel.length + 200;
-  const calcSVGPathLineWidth = () => {
-    const svgLineWidth = getLineWidth(targetRef);
+  const calcSVGPathLineWidth = async () => {
+    const svgLineWidth = await getLineWidth(targetRef);
     setLineWidth(svgLineWidth);
     const clientWidth = targetRef.current?.clientWidth;
     if (clientWidth) {

--- a/src/Chart/util/getLineWidth.ts
+++ b/src/Chart/util/getLineWidth.ts
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const getLineWidth = async (
+  ref: React.RefObject<HTMLDivElement>,
+): Promise<number> => {
+  while (true) {
+    const svg = ref.current?.querySelector(
+      'svg > g:last-child > path',
+    ) as SVGSVGElement;
+
+    const width: number | undefined = svg?.getBBox()?.width;
+    if (width) return width;
+
+    // eslint-disable-next-line no-await-in-loop
+    await delay(300);
+  }
+};
+
+export default getLineWidth;


### PR DESCRIPTION
# chart
- 차트 레이블 길이 잡을 때 해당 차트의 svg 너비를 얻기까지 루프를 도는 로직 추가