### PR TITLE
Release 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@earlysloth/pocketsurvey-ui-components",
-  "version": "0.8.99",
+  "version": "0.9.0",
   "module": "dist/index.js",
   "repository": "https://github.com/FJOQWIERMDNKFAJ/pocketsurvey-ui-components.git",
   "author": "earlysloth <survey@earlysloth.com>",

--- a/src/Changelog.stories.mdx
+++ b/src/Changelog.stories.mdx
@@ -8,6 +8,10 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 ui 컴포넌트에 반영된 사항들입니다
 
+## 0.9.0 (2021.10.06)
+  
+- ImgVideo의 qrCode 타입 수정
+ 
 ## 0.8.99 (2021.10.06)
   
 - ImgVideo index 에서 export처리

--- a/src/ShortText/img/ImgVideoUpload.tsx
+++ b/src/ShortText/img/ImgVideoUpload.tsx
@@ -120,7 +120,7 @@ const Sentence = styled.div`
 `
 export type ImgVideoType = {
   onClick: () => void;
-  qrCode: [string, string] | null;
+  qrCode: string | null;
   mediaSrc: string | null;
   type: "video" | "image";
   onUpload: ({isValid, file}:{isValid:boolean, file:File}) => void;


### PR DESCRIPTION
* ImgVideo의 qrCode 파라미터에서 기존에는 업로드토큰, qrCode를 둘 다 받도록 하였으나, 업로드 토큰이 필요가 없어 qrCode의 데이터만 받을 수 있도록 타입을 수정하였습니다. 